### PR TITLE
[WIP] Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,94 @@
+# OctoAcme Project Management Docs
+
+## Overview
+
+This directory contains the complete project management framework used by OctoAcme. These documents serve as the central hub for understanding how we run projects, define roles, manage risks, and drive continuous improvement across cross-functional teams.
+
+## 📚 Quick Start for New Team Members
+
+Start here:
+1. **[OctoAcme Project Management Overview](./octoacme-project-management-overview.md)** — High-level principles, roles, artifacts, and communication cadence.
+2. **[OctoAcme Roles and Personas](./octoacme-roles-and-personas.md)** — Understand responsibilities of Project Managers, Product Managers, Developers, QA, and Stakeholders.
+
+## 🔄 Project Lifecycle Guide
+
+Follow these docs in order as your project progresses:
+
+### **1. Initiation** 
+[Project Initiation Guide](./octoacme-project-initiation.md)
+- Validate business need and create a one-pager
+- Identify stakeholders and confirm alignment
+- Make go/no-go decision to proceed to planning
+
+### **2. Planning**
+[Project Planning](./octoacme-project-planning.md)
+- Break work into shippable increments
+- Create prioritized backlog with acceptance criteria
+- Define Definition of Done and identify risks/dependencies
+
+### **3. Execution & Tracking**
+[Execution & Tracking](./octoacme-execution-and-tracking.md)
+- Daily standups, weekly delivery syncs, regular demos
+- GitHub Projects workflow with PR standards
+- Quality assurance: unit tests, integration tests, security scanning
+- Blocker escalation and metrics tracking
+
+### **4. Risk Management & Communication**
+[Risk Management & Communication](./octoacme-risks-and-communication.md)
+- Maintain and monitor the Risk Register
+- Manage dependencies and escalation paths
+- Use templates for weekly status updates and incident communication
+
+### **5. Release & Deployment**
+[Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- Pre-release requirements and deployment checklists
+- Rollback and incident playbook
+- Release notes and stakeholder announcements
+
+### **6. Retrospective & Continuous Improvement**
+[Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- Run structured retrospectives after sprints or releases
+- Capture action items with owners and due dates
+- Track improvements and celebrate wins
+
+---
+
+## 📖 Core Processes Summary
+
+**OctoAcme applies a structured, transparent approach to project management that empowers cross-functional teams and drives continuous improvement.** Projects progress through five clear lifecycle phases: Initiation, Planning, Execution & Tracking, Release & Deployment, and Retrospective. Initiatives begin with a focused one-pager that clarifies the business need, expected outcomes, core stakeholders, timeline estimates, and initial risk assessment. The Planning phase then decomposes this into actionable backlogs, aligns teams on timelines and milestones, defines clear Acceptance Criteria and Definition of Done, and establishes robust risk and dependency tracking. Execution leverages established workflows including prioritized project boards (GitHub Projects), daily standups, regular delivery syncs, and structured escalation paths for blockers, all designed to reduce surprises and keep delivery predictable.
+
+**Distinct roles with clearly documented responsibilities enable efficient collaboration and ownership clarity.** Project Managers coordinate schedules, manage dependencies, and own communication; Product Managers steer backlog priorities and measure success against defined metrics; Developers and QA focus on building quality features with strong test coverage; Stakeholders provide critical inputs and approvals. This shared role understanding ensures effective handoffs and enables fast escalation when needed. Communication cadence is deliberate and role-tailored: weekly PM/PdM syncs for alignment, twice-weekly team standups for immediate progress tracking, monthly stakeholder updates for high-level visibility, and ad-hoc escalations for urgent blockers. Clear communication templates (Weekly Status, Incident Communication) keep all parties informed and reduce ambiguity.
+
+**Quality assurance is embedded throughout OctoAcme processes, with mandatory unit, integration, and end-to-end smoke tests, automated CI/CD workflows including security scanning, and peer-review standards for all Pull Requests (minimum one approval, typically ≤400 lines per PR).** Releases follow rigorous pre-deployment, deployment, and rollback checklists to minimize production risk; release notes are templated and distributed to stakeholders. Risk management is foundational to every phase: risks are captured in a formal register, assessed for impact and likelihood, assigned to owners with clear mitigation plans, and reviewed at weekly syncs. Structured escalation paths (Team → PM → Product Lead → Sponsor) ensure issues are triaged appropriately and resolved quickly.
+
+**Continuous improvement is woven into OctoAcme's DNA through regular retrospectives following each sprint, release, or significant milestone.** Retrospectives capture what went well, what could improve, and distill 2–3 actionable items (each with an owner and due date) to prevent improvement fatigue. Action items are tracked in the project backlog and reviewed weekly, with impact measurement ensuring that changes truly drive value. This combination of structured processes, clear role ownership, transparent communication, embedded quality gates, and continuous learning minimizes single points of failure, accelerates onboarding for new team members, and enables repeatable project success across OctoAcme.
+
+---
+
+## 📋 All Documents
+
+- [octoacme-project-management-overview.md](./octoacme-project-management-overview.md)
+- [octoacme-project-initiation.md](./octoacme-project-initiation.md)
+- [octoacme-project-planning.md](./octoacme-project-planning.md)
+- [octoacme-execution-and-tracking.md](./octoacme-execution-and-tracking.md)
+- [octoacme-risks-and-communication.md](./octoacme-risks-and-communication.md)
+- [octoacme-release-and-deployment.md](./octoacme-release-and-deployment.md)
+- [octoacme-retrospective-and-continuous-improvement.md](./octoacme-retrospective-and-continuous-improvement.md)
+- [octoacme-roles-and-personas.md](./octoacme-roles-and-personas.md)
+
+---
+
+## 💡 How to Use These Docs
+
+- **Keep project charters updated** in your project repository and reference this framework.
+- **Link to specific process docs** when onboarding new team members or during project kickoffs.
+- **Add process-specific docs** to `.copilot/` if you want Copilot Spaces to use them as context for role-specific guidance.
+- **Contribute improvements** by proposing updates to any process doc via the "Add Content to Project Management Process Docs" issue template.
+
+---
+
+## 🤝 Contributing
+
+To propose updates or new content to these process documents, use the **["Add Content to Project Management Process Docs"](../.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml)** issue template.
+
+Last updated: 2026-04-24


### PR DESCRIPTION
This document serves as the central hub for understanding the OctoAcme project management framework, detailing processes, roles, and guidelines for team members.

## Related Issue
Fixes [https://github.com/nilay-epam/skills-scale-institutional-knowledge-using-copilot-spaces/issues/2](url)